### PR TITLE
fix-error-expected-unqualified-id-before-token

### DIFF
--- a/MediaSession.h
+++ b/MediaSession.h
@@ -39,6 +39,8 @@
 #undef __in
 #undef __out
 
+#undef __reserved
+
 #include <string.h>
 #include <memory>
 #include <interfaces/IDRM.h>


### PR DESCRIPTION
fixes 
```
make[4]: *** [CMakeFiles/Playready.dir/build.make:76: CMakeFiles/Playready.dir/MediaSession.cpp.o] Error 1
In file included from ../../host/arm-buildroot-linux-gnueabihf/sysroot/usr/include/bits/statx.h:31,
                 from ../../host/arm-buildroot-linux-gnueabihf/sysroot/usr/include/sys/stat.h:465,
                 from ../../host/arm-buildroot-linux-gnueabihf/sysroot/usr/include/WPEFramework/core/Portability.h:398,
                 from ../../host/arm-buildroot-linux-gnueabihf/sysroot/usr/include/WPEFramework/core/Module.h:26,
                 from ../../host/arm-buildroot-linux-gnueabihf/sysroot/usr/include/WPEFramework/core/core.h:27,
                 from MediaSession.h:46,
                 from MediaSystem.cpp:23:
../../host/arm-buildroot-linux-gnueabihf/sysroot/usr/include/linux/stat.h:59:9: error: declaration does not declare anything [-fpermissive]
   59 |         _s32   _reserved;
      |         ^~~~~
make[4]: *** [CMakeFiles/Playready.dir/build.make:90: CMakeFiles/Playready.dir/MediaSystem.cpp.o] Error 1
make[3]: *** [CMakeFiles/Makefile2:83: CMakeFiles/Playready.dir/all] Error 2
```